### PR TITLE
Disabled migrations if no DB connection is given

### DIFF
--- a/config/translation.php
+++ b/config/translation.php
@@ -68,6 +68,7 @@ return [
     */
     'database' => [
 
+        // Leave empty to disable migrations
         'connection' => '',
 
         'languages_table' => 'languages',

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -115,6 +115,11 @@ class TranslationServiceProvider extends ServiceProvider
      */
     private function loadMigrations()
     {
+        // Don't migrate if no database connection is given
+        if (!config('translation.database.connection')) {
+            return;
+        }
+
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 


### PR DESCRIPTION
This gives the package user the option to not use the database migrations and avoid empty tables being created.